### PR TITLE
documentation update

### DIFF
--- a/lib/File/SearchPath.pm
+++ b/lib/File/SearchPath.pm
@@ -57,7 +57,7 @@ can include directory specifications.
   @matches = searchpath( $file );
 
 If only two arguments are provided, it is assumed that the second
-argument is a path like variable. This interface is provided for
+argument is a path-like string. This interface is provided for
 backwards compatibility with C<File::SearchPath> version 0.01. It is not
 as portable as specifying the name of the environment variable. Note also
 that no specific attempt will be made to check whether the file is

--- a/lib/File/SearchPath.pm
+++ b/lib/File/SearchPath.pm
@@ -56,8 +56,8 @@ can include directory specifications.
   $path = searchpath( $file );
   @matches = searchpath( $file );
 
-If a second argument is provided, it is assumed to be
-a path like variable. This interface is provided for
+If only two arguments are provided, it is assumed that the second
+argument is a path like variable. This interface is provided for
 backwards compatibility with C<File::SearchPath> version 0.01. It is not
 as portable as specifying the name of the environment variable. Note also
 that no specific attempt will be made to check whether the file is
@@ -68,7 +68,7 @@ executable when the subroutine is called in this way.
 By default, this will search in $PATH for executable files and is
 equivalent to:
 
-  $path = searchpath( $file, env => 'PATH', exe => 1 );
+  $path = searchpath( $file, env => 'PATH', exe => 0 );
 
 Hash-like options can be used to alter the behaviour of the
 search:

--- a/t/search.t
+++ b/t/search.t
@@ -1,6 +1,6 @@
 # -*-perl-*-
 
-use Test::More tests => 14;
+use Test::More tests => 16;
 use File::Spec;
 use Config;
 
@@ -49,8 +49,13 @@ is($full[1], File::Spec->catfile("t","b","file2"),"found file2");
 # Now for backwards compatibility
 @full = File::SearchPath::searchpath( "file2", $ENV{MYPATH} );
 is(@full, 2, "Number of files found in backcompat mode" );
-is($full[0], File::Spec->catfile("t","a","file2"),"found file2");
-is($full[1], File::Spec->catfile("t","b","file2"),"found file2");
+is($full[0], File::Spec->catfile("t","a","file2"),"found file2 [backcompat]");
+is($full[1], File::Spec->catfile("t","b","file2"),"found file2 [backcompat]");
+
+# Backwards compatibility equivalency
+@compat = File::SearchPath::searchpath( "file2", env => "MYPATH", exe => 0 );
+is($full[0], $compat[0], "backcompat matches normal file2");
+is($full[1], $compat[1], "backcompat matches normal file2");
 
 # Search for a directory (curdir first since we expect this to match
 # current directory and CPAN testers sets $TMPDIR to the current directory)


### PR DESCRIPTION
So ... I updated the docs and added a couple of tests.

However, your email said "...a test that should fail to find something because it's an executable in that fallback mode..." and that caused a bit of confusion because that's not what exe => 0 does apparently.  From what I can see, exe => 1 will only return results that are executable, but exe => 0 will return results whether they are executable or not.   Your email would imply that this is a bug.

But, another way to look at things is that exe => 1 could mean "test that the file is executable" and dir => 1 could mean "test that the 'file' is a directory", while the => 0 versions of those mean "don't perform this test". My reading of the existing docs jibes with this interpretation.  However, this would mean that dir => 0 currently has a bug.  [As an aside, under this interpretation, you actually could have both exe => 1 and dir => 1 rather than croak as you do now]

Either way I think there's a bug somewhere and that the docs need to be updated to clearly reflect whichever interpretation is correct.  

If you open an RT or github issue with guidance on which way you want to go, I'll fix it  :-)
